### PR TITLE
Added digestSize 128

### DIFF
--- a/lib/blake2b.dart
+++ b/lib/blake2b.dart
@@ -20,7 +20,9 @@ import 'package:fixnum/fixnum.dart';
 /// Blake2b
 class Blake2b {
   Blake2b(int digestSize) {
-    assert(digestSize == 160 ||
+    assert(
+        digestSize == 128 ||
+        digestSize == 160 ||
         digestSize == 256 ||
         digestSize == 384 ||
         digestSize == 512);


### PR DESCRIPTION
This allows for new functionality such as blake2b128 concat which is required to interact with the polkadot blockchain.


Blake2b128 Example
``` dart
final msg = Uint8List.fromList("abc".codeUnits);
final b = Blake2b(128);
final bytes = Uint8List(16);
b.update(msg, 0, msg.length);
final hashResult = Uint8List.fromList(_hasher.digest(bytes, 0));
```